### PR TITLE
Quotes around source and destination

### DIFF
--- a/rclone.sh
+++ b/rclone.sh
@@ -30,7 +30,7 @@ echo "$( date +'%Y/%m/%d %H:%M:%S' ) Tidying empty directories in $SOURCE"
 find "$SOURCE" -mindepth 2 -depth -not -path '*/\.*' -type d -exec rmdir -p --ignore-fail-on-non-empty {} \;
 
 echo -e "$( date +'%Y/%m/%d %H:%M:%S' ) rclone $CONFIG_OPTS $COMMAND $COMMAND_OPTS $SOURCE $DESTINATION"
-rclone $CONFIG_OPTS $COMMAND $COMMAND_OPTS $SOURCE $DESTINATION
+rclone $CONFIG_OPTS $COMMAND $COMMAND_OPTS "$SOURCE" "$DESTINATION"
 
 if [[ ! -z "$HEALTH_URL" ]]; then
   echo "$( date +'%Y/%m/%d %H:%M:%S' ) Pinging $HEALTH_URL"


### PR DESCRIPTION
This hopefully fixes the image not working when using spaces in the source and/or destination.

I'm using this `docker run` command on a synology nas, trying to sync the `/volume1/media/Losse fotos` folder to `drive:media/Losse fotos` destination:

```docker run --rm --name=rclone-media --rm -it -v /volume1/docker/docker-rclone/:/config/ -v /volume1/media/:/source \
--env CRON_ENABLED=1 \
--env CRON="* * * * *" \
--env SOURCE="/source/Losse fotos" \
--env DESTINATION="drive:media/Losse fotos" \
--env COMMAND_OPTS='--exclude @eaDir/** --exclude "\#recycle" -v --stats=5s --checkers=32 --transfers=16' \
--env TZ="Europe/Amsterdam" \
drvdijk/rclone-sync
```

Before surrounding the `SOURCE` and `DESTINATION` with `""` quotes, it'd fail, as it'd consider `/source/Losse` as source, and `fotos` as destination.